### PR TITLE
Information distance was all NaN

### DIFF
--- a/src/distx.c
+++ b/src/distx.c
@@ -213,8 +213,8 @@ double xx_information(double *x, int nr, int nc, int i1, int i2)
     for(j=0; j<nc; j++) {
 	if(R_FINITE(x[i1]) && R_FINITE(x[i2])) {
 	    XY = x[i1] + x[i2];
-	    A += x[i1] * (log((2 * x[i1]) / XY)/log(2));
-	    B += x[i2] * (log((2 * x[i2]) / XY)/log(2));
+	    A = x[i1] * (log((2 * x[i1]) / XY)/log(2));
+	    B = x[i2] * (log((2 * x[i2]) / XY)/log(2));
 	    if(R_FINITE(A)) {
 		Adist += A;
 	    }
@@ -227,7 +227,7 @@ double xx_information(double *x, int nr, int nc, int i1, int i2)
 	i2 += nr;
     }
     if(count==0) return NA_REAL;
-    dist = A + B;
+    dist = Adist + Bdist;
     return dist;
 }
 

--- a/src/distxy.c
+++ b/src/distxy.c
@@ -227,8 +227,8 @@ double xy_information(double *x, double *y, int nr1, int nr2,
     for(j=0; j<nc; j++) {
 	if(R_FINITE(x[i1]) && R_FINITE(y[i2])) {
 	    XY = x[i1] + y[i2];
-	    A += x[i1] * (log((2 * x[i1]) / XY)/log(2));
-	    B += y[i2] * (log((2 * y[i2]) / XY)/log(2));
+	    A = x[i1] * (log((2 * x[i1]) / XY)/log(2));
+	    B = y[i2] * (log((2 * y[i2]) / XY)/log(2));
 	    if(R_FINITE(A)) {
 		Adist += A;
 	    }
@@ -241,7 +241,7 @@ double xy_information(double *x, double *y, int nr1, int nr2,
 	i2 += nr2;
     }
     if(count==0) return NA_REAL;
-    dist = A + B;
+    dist = Adist + Bdist;
     return dist;
 }
 


### PR DESCRIPTION
This is a long-standing bug that propagated NaN to all entries of information distance in new distx.c and distxy.c code, whereas the R code of oldDistance worked. Now new C code and old R code give numerically identical results.

The NaN obviously appeared when both columns (species) were zero and the sum of species was 0 leading to expression 0/0, and there was an idea (via Adist,Bdist) to fix this, but it was not implemented.