### PR TITLE
bug fix: information distance is NaN if there are any zeros in the data

### DIFF
--- a/src/distx.c
+++ b/src/distx.c
@@ -201,25 +201,21 @@ double xx_sq_chi_square(double *x, int nr, int nc, int i1, int i2)
 /* information statistic */
 double xx_information(double *x, int nr, int nc, int i1, int i2)
 {
-    double dist, XY, A, B, Adist, Bdist;
+    double dist, XY, A, B;
     int count, j;
     
     count = 0;
     dist = 0.0;
-    Adist = 0.0;
-    Bdist = 0.0;
     A = 0.0;
     B = 0.0;
     for(j=0; j<nc; j++) {
 	if(R_FINITE(x[i1]) && R_FINITE(x[i2])) {
 	    XY = x[i1] + x[i2];
-	    A += x[i1] * (log((2 * x[i1]) / XY)/log(2));
-	    B += x[i2] * (log((2 * x[i2]) / XY)/log(2));
-	    if(R_FINITE(A)) {
-		Adist += A;
+	    if (x[i1] > 0.0) {
+	        A += x[i1] * (log((2 * x[i1]) / XY)/log(2));
 	    }
-	    if(R_FINITE(B)) {
-		Bdist += B;
+	    if (x[i2] > 0.0) { 
+		B += x[i2] * (log((2 * x[i2]) / XY)/log(2));
 	    }
 	    count++;
 	}

--- a/src/distx.c
+++ b/src/distx.c
@@ -212,10 +212,10 @@ double xx_information(double *x, int nr, int nc, int i1, int i2)
 	if(R_FINITE(x[i1]) && R_FINITE(x[i2])) {
 	    XY = x[i1] + x[i2];
 	    if (x[i1] > 0.0) {
-	        A += x[i1] * (log((2 * x[i1]) / XY)/log(2));
+	        A += x[i1] * (log((2 * x[i1]) / XY) / M_LN2);
 	    }
 	    if (x[i2] > 0.0) { 
-		B += x[i2] * (log((2 * x[i2]) / XY)/log(2));
+		B += x[i2] * (log((2 * x[i2]) / XY) / M_LN2);
 	    }
 	    count++;
 	}

--- a/src/distxy.c
+++ b/src/distxy.c
@@ -215,25 +215,21 @@ double xy_sq_chi_square(double *x, double *y, int nr1, int nr2,
 double xy_information(double *x, double *y, int nr1, int nr2, 
 		      int nc, int i1, int i2)
 {
-    double dist, XY, A, B, Adist, Bdist;
+    double dist, XY, A, B;
     int count, j;
     
     count = 0;
     dist = 0.0;
-    Adist = 0.0;
-    Bdist = 0.0;
     A = 0.0;
     B = 0.0;
     for(j=0; j<nc; j++) {
 	if(R_FINITE(x[i1]) && R_FINITE(y[i2])) {
 	    XY = x[i1] + y[i2];
-	    A += x[i1] * (log((2 * x[i1]) / XY)/log(2));
-	    B += y[i2] * (log((2 * y[i2]) / XY)/log(2));
-	    if(R_FINITE(A)) {
-		Adist += A;
+	    if (x[i1] > 0.0) {
+		 A += x[i1] * (log((2 * x[i1]) / XY)/log(2));
 	    }
-	    if(R_FINITE(B)) {
-		Bdist += B;
+	    if (y[i2] > 0.0) {
+		 B += y[i2] * (log((2 * y[i2]) / XY)/log(2));
 	    }
 	    count++;
 	}

--- a/src/distxy.c
+++ b/src/distxy.c
@@ -226,10 +226,10 @@ double xy_information(double *x, double *y, int nr1, int nr2,
 	if(R_FINITE(x[i1]) && R_FINITE(y[i2])) {
 	    XY = x[i1] + y[i2];
 	    if (x[i1] > 0.0) {
-		 A += x[i1] * (log((2 * x[i1]) / XY)/log(2));
+		 A += x[i1] * (log((2 * x[i1]) / XY) / M_LN2);
 	    }
 	    if (y[i2] > 0.0) {
-		 B += y[i2] * (log((2 * y[i2]) / XY)/log(2));
+		 B += y[i2] * (log((2 * y[i2]) / XY) / M_LN2);
 	    }
 	    count++;
 	}


### PR DESCRIPTION
If _x_ or _y_ is zero, the expression for information distance simplifies to 0 * log(0) which is NaN, and if there is any NaN, the sum is NaN. Therefore information distance is NaN always when there is any zero for any species in compared sites. In most cases, it always returns a matrix of NaNs only.

log(0) is -Inf, but 0 * (-Inf) is NaN. So we should skip these zero entries completely. Please note that $\lim_{x \to 0^+} x \log(x) = 0$. So it is right to skip zeros since they add nothing to the sum.

C has currently function log2 for base-2 logs, but I am not sure if this is completely portable. I didn't use this, but instead I replaced evaluation of log(2) with constant M_LN2 defined in Rmath.h.

With this fix, `distance` and `oldDistance` return numerically equal results within magnitude 10<sup>-15</sup>.

This PR replaces earlier PR #27.